### PR TITLE
Refactorings: bug & linter fixes, code simplifications

### DIFF
--- a/client/connectionpool.go
+++ b/client/connectionpool.go
@@ -114,7 +114,7 @@ RunLoop:
 		}
 		// waitpool cleanup
 		var (
-			waitPoolLoosers = []int{}
+			waitPoolLoosers []int
 			now             = time.Now()
 		)
 		for i, waitPoolEntry := range waitPool {

--- a/client/httptransport.go
+++ b/client/httptransport.go
@@ -33,7 +33,7 @@ func (ht *httpTransport) call(handler server.Handler, request interface{}, respo
 	req, errNewRequest := http.NewRequest(
 		http.MethodPost,
 		ht.endpoint+"/"+string(handler),
-		bytes.NewBuffer(requestBytes),
+		bytes.NewReader(requestBytes),
 	)
 	if errNewRequest != nil {
 		return errNewRequest
@@ -53,9 +53,5 @@ func (ht *httpTransport) call(handler server.Handler, request interface{}, respo
 	if errRead != nil {
 		return errRead
 	}
-	errUnmarshal := json.Unmarshal(responseBytes, &serverResponse{Reply: response})
-	if errUnmarshal != nil {
-		return errUnmarshal
-	}
-	return errUnmarshal
+	return json.Unmarshal(responseBytes, &serverResponse{Reply: response})
 }

--- a/client/sockettransport.go
+++ b/client/sockettransport.go
@@ -34,9 +34,9 @@ func newSocketTransport(server string, connectionPoolSize int, waitTimeout time.
 	}
 }
 
-func (st *socketTransport) shutdown() {
-	if st.connPool.chanDrainPool != nil {
-		st.connPool.chanDrainPool <- 1
+func (c *socketTransport) shutdown() {
+	if c.connPool.chanDrainPool != nil {
+		c.connPool.chanDrainPool <- 1
 	}
 }
 
@@ -79,7 +79,7 @@ func (c *socketTransport) call(handler server.Handler, request interface{}, resp
 
 	// read response
 	var (
-		responseBytes  = []byte{}
+		responseBytes  = make([]byte, 0, 8192)
 		buf            = make([]byte, 4096)
 		responseLength = 0
 	)

--- a/repo/history.go
+++ b/repo/history.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -132,6 +131,6 @@ func (h *history) getCurrent(buf *bytes.Buffer) (err error) {
 		return err
 	}
 	defer f.Close()
-	_, err = io.Copy(buf, f)
+	_, err = buf.ReadFrom(f)
 	return err
 }

--- a/repo/history_test.go
+++ b/repo/history_test.go
@@ -32,7 +32,7 @@ func TestHistoryCurrent(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(b.Bytes(), test) {
-		t.Fatal(fmt.Sprintf("expected %q, got %q", string(test), string(b.Bytes())))
+		t.Fatal(fmt.Sprintf("expected %q, got %q", string(test), b.String()))
 	}
 }
 

--- a/repo/mock/mock.go
+++ b/repo/mock/mock.go
@@ -25,7 +25,7 @@ func GetMockData(t testing.TB) (server *httptest.Server, varDir string) {
 	}))
 	varDir, err := ioutil.TempDir("", "content-server-test")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	return server, varDir
 }
@@ -37,7 +37,7 @@ func MakeNodesRequest() *requests.Nodes {
 			Dimensions: []string{"dimension_foo"},
 		},
 		Nodes: map[string]*requests.Node{
-			"test": &requests.Node{
+			"test": {
 				ID:         "id-root",
 				Dimension:  "dimension_foo",
 				MimeTypes:  []string{},
@@ -66,7 +66,7 @@ func MakeValidContentRequest() *requests.Content {
 			Groups:     []string{},
 		},
 		Nodes: map[string]*requests.Node{
-			"id-root": &requests.Node{
+			"id-root": {
 				ID:         "id-root",
 				Dimension:  dimensions[0],
 				MimeTypes:  []string{"application/x-node"},

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -92,10 +92,8 @@ func TestLoadRepo(t *testing.T) {
 }
 
 func BenchmarkLoadRepo(b *testing.B) {
-
 	var (
-		t                  = &testing.T{}
-		mockServer, varDir = mock.GetMockData(t)
+		mockServer, varDir = mock.GetMockData(b)
 		server             = mockServer.URL + "/repo-ok.json"
 		r                  = NewTestRepo(server, varDir)
 	)

--- a/responses/responses.go
+++ b/responses/responses.go
@@ -10,15 +10,15 @@ type Error struct {
 }
 
 func (e Error) Error() string {
-	return fmt.Sprintf("status:%q, code: %q, message: %q", e.Status, e.Code, e.Message)
+	return fmt.Sprintf("status:%d, code:%d, message:%q", e.Status, e.Code, e.Message)
 }
 
-// NewError - a brand new error
-func NewError(code int, message string) *Error {
+// NewError - a brand new error using fmt.Sprintf
+func NewErrorf(code int, message string, args ...interface{}) *Error {
 	return &Error{
 		Status:  500,
 		Code:    code,
-		Message: message,
+		Message: fmt.Sprintf(message, args...),
 	}
 }
 

--- a/server/handlerequest.go
+++ b/server/handlerequest.go
@@ -55,17 +55,17 @@ func handleRequest(r *repo.Repo, handler Handler, jsonBytes []byte, source strin
 		})
 
 	default:
-		reply = responses.NewError(1, "unknown handler: "+string(handler))
+		reply = responses.NewErrorf(1, "unknown handler: "+string(handler))
 	}
 	addMetrics(handler, start, jsonErr, apiErr, source)
 
 	// error handling
 	if jsonErr != nil {
 		Log.Error("could not read incoming json", zap.Error(jsonErr))
-		reply = responses.NewError(2, "could not read incoming json "+jsonErr.Error())
+		reply = responses.NewErrorf(2, "could not read incoming json %s", jsonErr)
 	} else if apiErr != nil {
 		Log.Error("an API error occured", zap.Error(apiErr))
-		reply = responses.NewError(3, "internal error "+apiErr.Error())
+		reply = responses.NewErrorf(3, "internal error %s", apiErr)
 	}
 
 	return encodeReply(reply)

--- a/server/socketserver.go
+++ b/server/socketserver.go
@@ -111,7 +111,7 @@ func (s *socketServer) handleConnection(conn net.Conn) {
 			header = ""
 			if headerErr != nil {
 				Log.Error("invalid request could not read header", zap.Error(headerErr))
-				encodedErr, encodingErr := encodeReply(responses.NewError(4, "invalid header "+headerErr.Error()))
+				encodedErr, encodingErr := encodeReply(responses.NewErrorf(4, "invalid header %s", headerErr))
 				if encodingErr == nil {
 					s.writeResponse(conn, encodedErr)
 				} else {


### PR DESCRIPTION
- use NewReader instead of NewBuffer
- return errors directly without err != nil checks
- consistent naming of method receivers
- pre-allocate buffers and other slices
- use t.Fatal instead of panic
- use buf.ReadFrom instead of io.Copy
- for/select to for/range on channel
- rename internal functions for better understanding
- use bufio.NewReaderSize when reading from disk because AWS/GCP can
  be slow.

@loeffert please critically review, the 2nd PR depends at bit on this PR