### PR TITLE
Server streaming

### DIFF
--- a/client/connectionpool.go
+++ b/client/connectionpool.go
@@ -114,7 +114,7 @@ RunLoop:
 		}
 		// waitpool cleanup
 		var (
-			waitPoolLoosers = []int{}
+			waitPoolLoosers []int
 			now             = time.Now()
 		)
 		for i, waitPoolEntry := range waitPool {

--- a/client/httptransport.go
+++ b/client/httptransport.go
@@ -33,7 +33,7 @@ func (ht *httpTransport) call(handler server.Handler, request interface{}, respo
 	req, errNewRequest := http.NewRequest(
 		http.MethodPost,
 		ht.endpoint+"/"+string(handler),
-		bytes.NewBuffer(requestBytes),
+		bytes.NewReader(requestBytes),
 	)
 	if errNewRequest != nil {
 		return errNewRequest
@@ -53,9 +53,5 @@ func (ht *httpTransport) call(handler server.Handler, request interface{}, respo
 	if errRead != nil {
 		return errRead
 	}
-	errUnmarshal := json.Unmarshal(responseBytes, &serverResponse{Reply: response})
-	if errUnmarshal != nil {
-		return errUnmarshal
-	}
-	return errUnmarshal
+	return json.Unmarshal(responseBytes, &serverResponse{Reply: response})
 }

--- a/client/sockettransport.go
+++ b/client/sockettransport.go
@@ -34,9 +34,9 @@ func newSocketTransport(server string, connectionPoolSize int, waitTimeout time.
 	}
 }
 
-func (st *socketTransport) shutdown() {
-	if st.connPool.chanDrainPool != nil {
-		st.connPool.chanDrainPool <- 1
+func (c *socketTransport) shutdown() {
+	if c.connPool.chanDrainPool != nil {
+		c.connPool.chanDrainPool <- 1
 	}
 }
 
@@ -79,7 +79,7 @@ func (c *socketTransport) call(handler server.Handler, request interface{}, resp
 
 	// read response
 	var (
-		responseBytes  = []byte{}
+		responseBytes  = make([]byte, 0, 8192)
 		buf            = make([]byte, 4096)
 		responseLength = 0
 	)

--- a/repo/history.go
+++ b/repo/history.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -132,6 +131,6 @@ func (h *history) getCurrent(buf *bytes.Buffer) (err error) {
 		return err
 	}
 	defer f.Close()
-	_, err = io.Copy(buf, f)
+	_, err = buf.ReadFrom(f)
 	return err
 }

--- a/repo/history_test.go
+++ b/repo/history_test.go
@@ -32,7 +32,7 @@ func TestHistoryCurrent(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(b.Bytes(), test) {
-		t.Fatal(fmt.Sprintf("expected %q, got %q", string(test), string(b.Bytes())))
+		t.Fatal(fmt.Sprintf("expected %q, got %q", string(test), b.String()))
 	}
 }
 

--- a/repo/mock/mock.go
+++ b/repo/mock/mock.go
@@ -25,7 +25,7 @@ func GetMockData(t testing.TB) (server *httptest.Server, varDir string) {
 	}))
 	varDir, err := ioutil.TempDir("", "content-server-test")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	return server, varDir
 }
@@ -37,7 +37,7 @@ func MakeNodesRequest() *requests.Nodes {
 			Dimensions: []string{"dimension_foo"},
 		},
 		Nodes: map[string]*requests.Node{
-			"test": &requests.Node{
+			"test": {
 				ID:         "id-root",
 				Dimension:  "dimension_foo",
 				MimeTypes:  []string{},
@@ -66,7 +66,7 @@ func MakeValidContentRequest() *requests.Content {
 			Groups:     []string{},
 		},
 		Nodes: map[string]*requests.Node{
-			"id-root": &requests.Node{
+			"id-root": {
 				ID:         "id-root",
 				Dimension:  dimensions[0],
 				MimeTypes:  []string{"application/x-node"},

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -92,10 +92,8 @@ func TestLoadRepo(t *testing.T) {
 }
 
 func BenchmarkLoadRepo(b *testing.B) {
-
 	var (
-		t                  = &testing.T{}
-		mockServer, varDir = mock.GetMockData(t)
+		mockServer, varDir = mock.GetMockData(b)
 		server             = mockServer.URL + "/repo-ok.json"
 		r                  = NewTestRepo(server, varDir)
 	)

--- a/responses/responses.go
+++ b/responses/responses.go
@@ -10,15 +10,15 @@ type Error struct {
 }
 
 func (e Error) Error() string {
-	return fmt.Sprintf("status:%q, code: %q, message: %q", e.Status, e.Code, e.Message)
+	return fmt.Sprintf("status:%d, code:%d, message:%q", e.Status, e.Code, e.Message)
 }
 
-// NewError - a brand new error
-func NewError(code int, message string) *Error {
+// NewError - a brand new error using fmt.Sprintf
+func NewErrorf(code int, message string, args ...interface{}) *Error {
 	return &Error{
 		Status:  500,
 		Code:    code,
-		Message: message,
+		Message: fmt.Sprintf(message, args...),
 	}
 }
 

--- a/server/handlerequest.go
+++ b/server/handlerequest.go
@@ -55,17 +55,17 @@ func handleRequest(r *repo.Repo, handler Handler, jsonBytes []byte, source strin
 		})
 
 	default:
-		reply = responses.NewError(1, "unknown handler: "+string(handler))
+		reply = responses.NewErrorf(1, "unknown handler: "+string(handler))
 	}
 	addMetrics(handler, start, jsonErr, apiErr, source)
 
 	// error handling
 	if jsonErr != nil {
 		Log.Error("could not read incoming json", zap.Error(jsonErr))
-		reply = responses.NewError(2, "could not read incoming json "+jsonErr.Error())
+		reply = responses.NewErrorf(2, "could not read incoming json %s", jsonErr)
 	} else if apiErr != nil {
 		Log.Error("an API error occured", zap.Error(apiErr))
-		reply = responses.NewError(3, "internal error "+apiErr.Error())
+		reply = responses.NewErrorf(3, "internal error %s", apiErr)
 	}
 
 	return encodeReply(reply)

--- a/server/handlerequest_test.go
+++ b/server/handlerequest_test.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/foomo/contentserver/content"
+	"github.com/foomo/contentserver/logger"
+	"github.com/foomo/contentserver/repo"
+	"github.com/foomo/contentserver/requests"
+	"github.com/foomo/contentserver/responses"
+	"go.uber.org/zap"
+)
+
+// Test if we still maintain the contract with the upstream package
+var _ repoer = (*repo.Repo)(nil)
+var _ repoer = (*mockRepoer)(nil)
+
+type mockRepoer struct {
+	getContentErr error
+}
+
+func (mockRepoer) GetURIs(dimension string, ids []string) map[string]string {
+	return map[string]string{"uri1": "value1"}
+}
+
+func (m mockRepoer) GetContent(*requests.Content) (*content.SiteContent, error) {
+	if m.getContentErr != nil {
+		return nil, m.getContentErr
+	}
+	return &content.SiteContent{
+		URI: "uri1",
+	}, nil
+}
+
+func (mockRepoer) GetNodes(*requests.Nodes) map[string]*content.Node {
+	return map[string]*content.Node{
+		"node1": {
+			Index: []string{"index1"},
+		},
+	}
+}
+
+func (mockRepoer) Update() *responses.Update {
+	return &responses.Update{Success: true}
+}
+
+func (mockRepoer) WriteRepoBytes(io.Writer) {}
+
+func objectToJsonReader(t *testing.T, o interface{}) io.Reader {
+	data, err := json.Marshal(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes.NewReader(data)
+}
+
+func TestHandleRequest_WebServer(t *testing.T) {
+	logger.Log = zap.New(nil)
+
+	runTest := func(handler Handler, reqObject interface{}, want string) func(*testing.T) {
+		return func(t *testing.T) {
+			rdr := objectToJsonReader(t, reqObject)
+			var wr bytes.Buffer
+			if err := handleRequest(mockRepoer{}, handler, rdr, &wr, "webserver"); err != nil {
+				t.Error(err)
+			}
+			if have := wr.String(); have != want {
+				t.Errorf("\nhave: %q\nwant: %q", have, want)
+			}
+		}
+	}
+
+	t.Run("unknown handler", runTest(
+		"xx",
+		new(requests.URIs),
+		`{"reply":{"status":500,"code":1,"message":"unknown handler: xx"}}`+"\n"),
+	)
+
+	t.Run("HandlerGetURIs", runTest(
+		HandlerGetURIs,
+		&requests.URIs{
+			IDs:       []string{"a"},
+			Dimension: "dim1",
+		},
+		"{\"reply\":{\"uri1\":\"value1\"}}\n"),
+	)
+
+	t.Run("HandlerGetContent Ok", runTest(
+		HandlerGetContent,
+		&requests.Content{
+			URI:        "uri2",
+			DataFields: []string{"field1"},
+		},
+		"{\"reply\":{\"status\":0,\"URI\":\"uri1\",\"dimension\":\"\",\"mimeType\":\"\",\"item\":null,\"data\":null,\"path\":null,\"URIs\":null,\"nodes\":null}}\n"),
+	)
+
+	t.Run("HandlerGetContent Err", func(t *testing.T) {
+		rdr := objectToJsonReader(t, &requests.Content{
+			URI:        "uri2",
+			DataFields: []string{"field1"},
+		}, )
+		var wr bytes.Buffer
+		if err := handleRequest(mockRepoer{
+			getContentErr: errors.New("upssss an error"),
+		}, HandlerGetContent, rdr, &wr, "webserver"); err != nil {
+			t.Error(err)
+		}
+		const want = "{\"reply\":{\"status\":500,\"code\":3,\"message\":\"internal error: upssss an error\"}}\n"
+		if have := wr.String(); have != want {
+			t.Errorf("\nhave: %q\nwant: %q", have, want)
+		}
+	})
+
+	t.Run("HandlerGetNodes", runTest(
+		HandlerGetNodes,
+		&requests.Nodes{
+			Nodes: map[string]*requests.Node{
+				"node1": {
+					ID: "id11",
+				},
+			},
+		},
+		"{\"reply\":{\"node1\":{\"item\":null,\"nodes\":null,\"index\":[\"index1\"]}}}\n"),
+	)
+
+	t.Run("HandlerUpdate", runTest(
+		HandlerUpdate,
+		requests.Update{},
+		"{\"reply\":{\"success\":true,\"errorMessage\":\"\",\"stats\":{\"numberOfNodes\":0,\"numberOfURIs\":0,\"repoRuntime\":0,\"ownRuntime\":0}}}\n"),
+	)
+
+}

--- a/server/server.go
+++ b/server/server.go
@@ -91,7 +91,7 @@ func runWebserver(
 }
 
 func runSocketServer(
-	repo *repo.Repo,
+	repo repoer,
 	address string,
 	chanErr chan error,
 ) {

--- a/server/socketserver.go
+++ b/server/socketserver.go
@@ -111,7 +111,7 @@ func (s *socketServer) handleConnection(conn net.Conn) {
 			header = ""
 			if headerErr != nil {
 				Log.Error("invalid request could not read header", zap.Error(headerErr))
-				encodedErr, encodingErr := encodeReply(responses.NewError(4, "invalid header "+headerErr.Error()))
+				encodedErr, encodingErr := encodeReply(responses.NewErrorf(4, "invalid header %s", headerErr))
 				if encodingErr == nil {
 					s.writeResponse(conn, encodedErr)
 				} else {

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -4,19 +4,17 @@ import (
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/foomo/contentserver/repo"
 )
 
 const sourceWebserver = "webserver"
 
 type webServer struct {
 	path string
-	r    *repo.Repo
+	r    repoer
 }
 
 // NewWebServer returns a shiny new web server
-func NewWebServer(path string, r *repo.Repo) http.Handler {
+func NewWebServer(path string, r repoer) http.Handler {
 	return &webServer{
 		path: path,
 		r:    r,
@@ -41,5 +39,7 @@ func (s *webServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := handleRequest(s.r, h, r.Body, w, "webserver"); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
-	r.Body.Close()
+	if err := r.Body.Close(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }


### PR DESCRIPTION
Refactorings: streaming in handleRequest

this PR depends partially on PR #16

- go linter fixes
- handleRequest is now io.Writer/Reader which improves HTTP but might
slow down a very tiny bit the socket server. The socket server could
be faster if we can avoid writing the length of JSON at the beginning
of each response ...
- socketServer.writeResponse uses correctly pre-allocated byte slice
- socketServer.handleConnection reduces amount of allocations by
using a bytes.buffer for the header (avoid += in strings) (this buffer
gets reused). Avoids headerBuffer to string conversion by comparing it
with a rune.
- socketServer.handleConnection: Maybe conn.Read should read a larger
buffer and search later for the `{` to avoid too many reads from the
network.

@loeffert please critically review it