### PR TITLE
bug & linter fixes, code simplifications

### DIFF
--- a/client/connectionpool.go
+++ b/client/connectionpool.go
@@ -114,7 +114,7 @@ RunLoop:
 		}
 		// waitpool cleanup
 		var (
-			waitPoolLoosers = []int{}
+			waitPoolLoosers []int
 			now             = time.Now()
 		)
 		for i, waitPoolEntry := range waitPool {

--- a/client/sockettransport.go
+++ b/client/sockettransport.go
@@ -34,9 +34,9 @@ func newSocketTransport(server string, connectionPoolSize int, waitTimeout time.
 	}
 }
 
-func (st *socketTransport) shutdown() {
-	if st.connPool.chanDrainPool != nil {
-		st.connPool.chanDrainPool <- 1
+func (c *socketTransport) shutdown() {
+	if c.connPool.chanDrainPool != nil {
+		c.connPool.chanDrainPool <- 1
 	}
 }
 
@@ -79,7 +79,7 @@ func (c *socketTransport) call(handler server.Handler, request interface{}, resp
 
 	// read response
 	var (
-		responseBytes  = []byte{}
+		responseBytes  []byte
 		buf            = make([]byte, 4096)
 		responseLength = 0
 	)
@@ -95,7 +95,7 @@ func (c *socketTransport) call(handler server.Handler, request interface{}, resp
 		responseBytes = append(responseBytes, buf[0:n]...)
 		if responseLength == 0 {
 			for index, byte := range responseBytes {
-				if byte == 123 {
+				if byte == '{' {
 					// opening bracket
 					responseLength, err = strconv.Atoi(string(responseBytes[0:index]))
 					if err != nil {

--- a/repo/history.go
+++ b/repo/history.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -132,6 +131,6 @@ func (h *history) getCurrent(buf *bytes.Buffer) (err error) {
 		return err
 	}
 	defer f.Close()
-	_, err = io.Copy(buf, f)
+	_, err = buf.ReadFrom(f)
 	return err
 }

--- a/repo/history_test.go
+++ b/repo/history_test.go
@@ -32,7 +32,7 @@ func TestHistoryCurrent(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(b.Bytes(), test) {
-		t.Fatal(fmt.Sprintf("expected %q, got %q", string(test), string(b.Bytes())))
+		t.Fatal(fmt.Sprintf("expected %q, got %q", string(test), b.String()))
 	}
 }
 

--- a/repo/loader.go
+++ b/repo/loader.go
@@ -3,7 +3,6 @@ package repo
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -25,27 +24,24 @@ type updateResponse struct {
 }
 
 func (repo *Repo) updateRoutine() {
-	for {
-		select {
-		case resChan := <-repo.updateInProgressChannel:
-			Log.Info("waiting for update to complete", zap.String("chan", fmt.Sprintf("%p", resChan)))
-			start := time.Now()
+	for resChan := range repo.updateInProgressChannel {
+		Log.Info("waiting for update to complete", zap.String("chan", fmt.Sprintf("%p", resChan)))
+		start := time.Now()
 
-			repoRuntime, errUpdate := repo.update()
-			if errUpdate != nil {
-				status.M.UpdatesFailedCounter.WithLabelValues(errUpdate.Error()).Inc()
-			}
-
-			resChan <- updateResponse{
-				repoRuntime: repoRuntime,
-				err:         errUpdate,
-			}
-
-			duration := time.Since(start)
-			Log.Info("update completed", zap.Duration("duration", duration), zap.String("chan", fmt.Sprintf("%p", resChan)))
-			status.M.UpdatesCompletedCounter.WithLabelValues().Inc()
-			status.M.UpdateDuration.WithLabelValues().Observe(duration.Seconds())
+		repoRuntime, errUpdate := repo.update()
+		if errUpdate != nil {
+			status.M.UpdatesFailedCounter.WithLabelValues(errUpdate.Error()).Inc()
 		}
+
+		resChan <- updateResponse{
+			repoRuntime: repoRuntime,
+			err:         errUpdate,
+		}
+
+		duration := time.Since(start)
+		Log.Info("update completed", zap.Duration("duration", duration), zap.String("chan", fmt.Sprintf("%p", resChan)))
+		status.M.UpdatesCompletedCounter.WithLabelValues().Inc()
+		status.M.UpdateDuration.WithLabelValues().Observe(duration.Seconds())
 	}
 }
 
@@ -172,34 +168,33 @@ func (repo *Repo) tryToRestoreCurrent() (err error) {
 	return repo.loadJSONBytes()
 }
 
-func (repo *Repo) get(URL string) (err error) {
+func (repo *Repo) loadRawHTTPBodyIntoBuffer(URL string) (err error) {
 	response, err := http.Get(URL)
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("Bad HTTP Response: %q", response.Status)
 	}
 
 	// Log.Info(ansi.Red + "RESETTING BUFFER" + ansi.Reset)
 	repo.jsonBuf.Reset()
-
 	// Log.Info(ansi.Green + "LOADING DATA INTO BUFFER" + ansi.Reset)
-	_, err = io.Copy(&repo.jsonBuf, response.Body)
+	_, err = repo.jsonBuf.ReadFrom(response.Body)
+	response.Body.Close()
 	return err
 }
 
 func (repo *Repo) update() (repoRuntime int64, err error) {
 	startTimeRepo := time.Now().UnixNano()
-	err = repo.get(repo.server)
+	err = repo.loadRawHTTPBodyIntoBuffer(repo.server)
 	repoRuntime = time.Now().UnixNano() - startTimeRepo
 	if err != nil {
 		// we have no json to load - the repo server did not reply
 		Log.Debug("failed to load json", zap.Error(err))
 		return repoRuntime, err
 	}
-	Log.Debug("loading json", zap.String("server", repo.server), zap.Int("length", len(repo.jsonBuf.Bytes())))
+	Log.Debug("loading json", zap.String("server", repo.server), zap.Int("length", repo.jsonBuf.Len()))
 	nodes, err := repo.loadNodesFromJSON()
 	if err != nil {
 		// could not load nodes from json
@@ -213,7 +208,7 @@ func (repo *Repo) update() (repoRuntime int64, err error) {
 	return repoRuntime, nil
 }
 
-// limit ressources and allow only one update request at once
+// limit resources and allow only one update request at once
 func (repo *Repo) tryUpdate() (repoRuntime int64, err error) {
 	c := make(chan updateResponse)
 	select {
@@ -256,7 +251,7 @@ func (repo *Repo) loadJSONBytes() error {
 }
 
 func (repo *Repo) loadNodes(newNodes map[string]*content.RepoNode) error {
-	newDimensions := []string{}
+	newDimensions := make([]string, 0, len(newNodes))
 	for dimension, newNode := range newNodes {
 		newDimensions = append(newDimensions, dimension)
 		Log.Debug("loading nodes for dimension", zap.String("dimension", dimension))

--- a/repo/mock/mock.go
+++ b/repo/mock/mock.go
@@ -25,7 +25,7 @@ func GetMockData(t testing.TB) (server *httptest.Server, varDir string) {
 	}))
 	varDir, err := ioutil.TempDir("", "content-server-test")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	return server, varDir
 }
@@ -37,7 +37,7 @@ func MakeNodesRequest() *requests.Nodes {
 			Dimensions: []string{"dimension_foo"},
 		},
 		Nodes: map[string]*requests.Node{
-			"test": &requests.Node{
+			"test": {
 				ID:         "id-root",
 				Dimension:  "dimension_foo",
 				MimeTypes:  []string{},
@@ -66,7 +66,7 @@ func MakeValidContentRequest() *requests.Content {
 			Groups:     []string{},
 		},
 		Nodes: map[string]*requests.Node{
-			"id-root": &requests.Node{
+			"id-root": {
 				ID:         "id-root",
 				Dimension:  dimensions[0],
 				MimeTypes:  []string{"application/x-node"},

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -60,7 +60,7 @@ func NewRepo(server string, varDir string) *Repo {
 		history:                    newHistory(varDir),
 		dimensionUpdateChannel:     make(chan *repoDimension),
 		dimensionUpdateDoneChannel: make(chan error),
-		updateInProgressChannel:    make(chan chan updateResponse, 0),
+		updateInProgressChannel:    make(chan chan updateResponse),
 	}
 
 	go repo.updateRoutine()
@@ -94,7 +94,7 @@ func (repo *Repo) getNodes(nodeRequests map[string]*requests.Node, env *requests
 
 	var (
 		nodes = map[string]*content.Node{}
-		path  = []*content.Item{}
+		path  []*content.Item
 	)
 	for nodeName, nodeRequest := range nodeRequests {
 
@@ -240,7 +240,7 @@ func (repo *Repo) WriteRepoBytes(w io.Writer) {
 // Update - reload contents of repository with json from repo.server
 func (repo *Repo) Update() (updateResponse *responses.Update) {
 	floatSeconds := func(nanoSeconds int64) float64 {
-		return float64(float64(nanoSeconds) / float64(1000000000.0))
+		return float64(nanoSeconds) / float64(1000000000.0)
 	}
 
 	Log.Info("Update triggered")

--- a/repo/repo_test.go
+++ b/repo/repo_test.go
@@ -92,10 +92,8 @@ func TestLoadRepo(t *testing.T) {
 }
 
 func BenchmarkLoadRepo(b *testing.B) {
-
 	var (
-		t                  = &testing.T{}
-		mockServer, varDir = mock.GetMockData(t)
+		mockServer, varDir = mock.GetMockData(b)
 		server             = mockServer.URL + "/repo-ok.json"
 		r                  = NewTestRepo(server, varDir)
 	)

--- a/responses/responses.go
+++ b/responses/responses.go
@@ -10,15 +10,15 @@ type Error struct {
 }
 
 func (e Error) Error() string {
-	return fmt.Sprintf("status:%q, code: %q, message: %q", e.Status, e.Code, e.Message)
+	return fmt.Sprintf("status:%d, code:%d, message:%q", e.Status, e.Code, e.Message)
 }
 
-// NewError - a brand new error
-func NewError(code int, message string) *Error {
+// NewError - a brand new error using fmt.Sprintf
+func NewErrorf(code int, message string, args ...interface{}) *Error {
 	return &Error{
 		Status:  500,
 		Code:    code,
-		Message: message,
+		Message: fmt.Sprintf(message, args...),
 	}
 }
 

--- a/server/handlerequest.go
+++ b/server/handlerequest.go
@@ -55,17 +55,17 @@ func handleRequest(r *repo.Repo, handler Handler, jsonBytes []byte, source strin
 		})
 
 	default:
-		reply = responses.NewError(1, "unknown handler: "+string(handler))
+		reply = responses.NewErrorf(1, "unknown handler: "+string(handler))
 	}
 	addMetrics(handler, start, jsonErr, apiErr, source)
 
 	// error handling
 	if jsonErr != nil {
 		Log.Error("could not read incoming json", zap.Error(jsonErr))
-		reply = responses.NewError(2, "could not read incoming json "+jsonErr.Error())
+		reply = responses.NewErrorf(2, "could not read incoming json %s", jsonErr)
 	} else if apiErr != nil {
 		Log.Error("an API error occured", zap.Error(apiErr))
-		reply = responses.NewError(3, "internal error "+apiErr.Error())
+		reply = responses.NewErrorf(3, "internal error %s", apiErr)
 	}
 
 	return encodeReply(reply)

--- a/server/socketserver.go
+++ b/server/socketserver.go
@@ -111,7 +111,7 @@ func (s *socketServer) handleConnection(conn net.Conn) {
 			header = ""
 			if headerErr != nil {
 				Log.Error("invalid request could not read header", zap.Error(headerErr))
-				encodedErr, encodingErr := encodeReply(responses.NewError(4, "invalid header "+headerErr.Error()))
+				encodedErr, encodingErr := encodeReply(responses.NewErrorf(4, "invalid header %s", headerErr))
 				if encodingErr == nil {
 					s.writeResponse(conn, encodedErr)
 				} else {


### PR DESCRIPTION
- use slim NewReader instead of big NewBuffer
- return errors directly without err != nil checks
- consistent naming of method receivers
- pre-allocate slices
- use t.Fatal instead of panic
- use buf.ReadFrom instead of io.Copy (io.Copy only for streaming and
  not reading into memory)
- for/select to for/range on channel
- rename internal functions for better understanding
- use json.NewDecoder to avoid ioutil.ReadAll. ReadAll duplicates the
  data in memory whereas NewDecoder can read directly from the
  Response.Body
- use rune '{' instead of ASCII code 123
- gofmt -s -w ./...
- change responses.NewError to NewErrorf to work with fmt.Sprintf