### PR TITLE
feat: add PathDataFields option on GetContent

### DIFF
--- a/content/reponode.go
+++ b/content/reponode.go
@@ -51,7 +51,7 @@ func (node *RepoNode) InPath(path []*Item) bool {
 }
 
 // GetPath get a path for a repo node
-func (node *RepoNode) GetPath() []*Item {
+func (node *RepoNode) GetPath(dataFields []string) []*Item {
 
 	var (
 		parentNode = node.parent
@@ -67,8 +67,13 @@ func (node *RepoNode) GetPath() []*Item {
 		i    = 0
 		path = make([]*Item, pathLength)
 	)
+
+	if dataFields == nil {
+		dataFields = []string{}
+	}
+
 	for parentNode != nil {
-		path[i] = parentNode.ToItem([]string{})
+		path[i] = parentNode.ToItem(dataFields)
 		parentNode = parentNode.parent
 		i++
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -13,11 +13,12 @@ import (
 
 	"github.com/foomo/contentserver/status"
 
+	"go.uber.org/zap"
+
 	"github.com/foomo/contentserver/content"
 	"github.com/foomo/contentserver/logger"
 	"github.com/foomo/contentserver/requests"
 	"github.com/foomo/contentserver/responses"
-	"go.uber.org/zap"
 )
 
 const maxGetURIForNodeRecursionLevel = 1000
@@ -199,7 +200,7 @@ func (repo *Repo) GetContent(r *requests.Content) (c *content.SiteContent, err e
 		c.Dimension = resolvedDimension
 		c.URI = resolvedURI
 		c.Item = node.ToItem(r.DataFields)
-		c.Path = node.GetPath()
+		c.Path = node.GetPath(r.PathDataFields)
 		// fetch URIs for all dimensions
 		uris := make(map[string]string)
 		for dimensionName := range repo.Directory {

--- a/requests/requests.go
+++ b/requests/requests.go
@@ -36,10 +36,11 @@ type Nodes struct {
 
 // Content - the standard request to contentserver
 type Content struct {
-	Env        *Env             `json:"env"`
-	URI        string           `json:"URI"`
-	Nodes      map[string]*Node `json:"nodes"`
-	DataFields []string         `json:"dataFields"`
+	Env            *Env             `json:"env"`
+	URI            string           `json:"URI"`
+	Nodes          map[string]*Node `json:"nodes"`
+	DataFields     []string         `json:"dataFields"`
+	PathDataFields []string         `json:"pathDataFields"`
 }
 
 // Update - request an update


### PR DESCRIPTION
Add `PathDataFields` on `GetContent` request to set data on the path items.

To be backward compatible we will see `nil` as `[]string` which will return nothing. 
This will prevent, that the path will contain all data in case it's not set.