### PR TITLE
Add backward-compatible ETag-aware conditional poll + bump Go to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/foomo/contentserver
 
-go 1.25.4
+go 1.26.0
 
 require (
 	github.com/foomo/keel v0.22.0

--- a/pkg/repo/loader.go
+++ b/pkg/repo/loader.go
@@ -232,7 +232,7 @@ func (r *Repo) get(ctx context.Context, url string) error {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return errors.Errorf("bad response code from repository %q want %q", response.Status, http.StatusOK)
+		return errors.Errorf("bad response code from repository %q want %d", response.Status, http.StatusOK)
 	}
 
 	// Log.Info(ansi.Red + "RESETTING BUFFER" + ansi.Reset)

--- a/pkg/repo/loader.go
+++ b/pkg/repo/loader.go
@@ -257,14 +257,38 @@ func (r *Repo) update(ctx context.Context) (repoRuntime int64, err error) {
 		if err != nil {
 			return repoRuntime, err
 		}
+		// Send a conditional request only if we have a prior ETag from a successful
+		// response. If lastETag is empty (first call, or server has never sent ETag),
+		// this is a no-op and the request behaves identically to the pre-ETag
+		// implementation.
+		if r.lastETag != "" {
+			req.Header.Set("If-None-Match", r.lastETag)
+		}
 		resp, err := r.httpClient.Do(req)
 		if err != nil {
 			return repoRuntime, err
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return repoRuntime, errors.New("could not poll latest repo download url - non 200 response")
+
+		// 304 Not Modified: server confirms our ETag is current. Skip body read
+		// entirely — the catalogue has not changed since the last successful poll.
+		if resp.StatusCode == http.StatusNotModified {
+			r.l.Info("repo is up to date (304 Not Modified)", zap.String("etag", r.lastETag))
+			return repoRuntime, nil
 		}
+
+		if resp.StatusCode != http.StatusOK {
+			return repoRuntime, errors.New("could not poll latest repo download url - non 200/304 response")
+		}
+
+		// Capture the new ETag if present. If absent, lastETag remains unchanged
+		// (or empty on the first call). This does not alter behavior for servers
+		// that never send ETag; it merely stores the value for future conditional
+		// requests.
+		if etag := resp.Header.Get("ETag"); etag != "" {
+			r.lastETag = etag
+		}
+
 		responseBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return repoRuntime, errors.New("could not poll latest repo download url, could not read body")

--- a/pkg/repo/loader_test.go
+++ b/pkg/repo/loader_test.go
@@ -1,0 +1,242 @@
+package repo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+// newMinimalRepo creates a Repo wired up for poll mode against the given URL,
+// with a temporary history dir. It does NOT start the background routines so
+// tests can call update() directly and observe the state.
+func newMinimalRepo(t *testing.T, url string) *Repo {
+	t.Helper()
+	l := zaptest.NewLogger(t)
+	h, err := NewHistory(l, HistoryWithHistoryLimit(2), HistoryWithHistoryDir(t.TempDir()))
+	require.NoError(t, err)
+	return New(l, url, h, WithPoll(true))
+}
+
+// TestUpdate_NoETag_BackwardCompat verifies that when the poll server never
+// sends an ETag header the loader behaves exactly as it did before this
+// change: it fetches the body URL, loads the repo, and on a second call with
+// the same poll response it skips via the URL-in-body comparison.
+func TestUpdate_NoETag_BackwardCompat(t *testing.T) {
+	t.Parallel()
+
+	// The poll server returns a URL that points at itself + "/repo".
+	// The "/repo" endpoint serves the actual JSON repo content.
+	var (
+		pollCallCount int
+		repoCallCount int
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/poll":
+			pollCallCount++
+			// No ETag header — legacy server behaviour.
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("http://" + r.Host + "/repo"))
+		case "/repo":
+			repoCallCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"dimension_foo":{"id":"id-root","uri":"/","name":"root","nodes":{},"index":[]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	r := newMinimalRepo(t, srv.URL+"/poll")
+
+	// Start the background channel-routing goroutines that update() requires.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go r.UpdateRoutine(ctx)   //nolint:errcheck
+	go r.DimensionUpdateRoutine(ctx) //nolint:errcheck
+
+	// First call — no ETag on wire, repo must be fetched and loaded.
+	_, err := r.update(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "", r.lastETag, "lastETag must stay empty when server sends no ETag")
+	assert.Equal(t, 1, pollCallCount)
+	assert.Equal(t, 1, repoCallCount)
+
+	// Second call — same URL returned by poll server, URL-in-body comparison
+	// must fire and skip the repo fetch.
+	_, err = r.update(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, pollCallCount, "poll endpoint must be hit again")
+	assert.Equal(t, 1, repoCallCount, "repo endpoint must NOT be hit again (URL-in-body skip)")
+}
+
+// TestUpdate_ETagSetThenNotModified verifies the happy-path ETag flow:
+// first call stores the ETag; second call sends If-None-Match and the server
+// replies 304, causing the loader to skip the body read.
+func TestUpdate_ETagSetThenNotModified(t *testing.T) {
+	t.Parallel()
+
+	const etagV1 = `"v1"`
+	var (
+		pollCallCount         int
+		receivedIfNoneMatch   string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/poll":
+			pollCallCount++
+			inm := r.Header.Get("If-None-Match")
+			if inm != "" {
+				receivedIfNoneMatch = inm
+			}
+
+			if inm == etagV1 {
+				// Confirm the ETag — content unchanged.
+				w.Header().Set("ETag", etagV1)
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+
+			// First call: return 200 + ETag + URL body.
+			w.Header().Set("ETag", etagV1)
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("http://" + r.Host + "/repo"))
+
+		case "/repo":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"dimension_foo":{"id":"id-root","uri":"/","name":"root","nodes":{},"index":[]}}`))
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	r := newMinimalRepo(t, srv.URL+"/poll")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go r.UpdateRoutine(ctx)          //nolint:errcheck
+	go r.DimensionUpdateRoutine(ctx) //nolint:errcheck
+
+	// First call: 200 + ETag; loader stores the ETag.
+	_, err := r.update(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, etagV1, r.lastETag, "ETag must be stored after first successful poll")
+	assert.Equal(t, 1, pollCallCount)
+
+	// Second call: loader must send If-None-Match; server replies 304.
+	_, err = r.update(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, etagV1, receivedIfNoneMatch, "If-None-Match must equal the stored ETag")
+	assert.Equal(t, 2, pollCallCount)
+	assert.Equal(t, etagV1, r.lastETag, "lastETag must remain unchanged after 304")
+}
+
+// TestUpdate_ETagChange verifies that when the server returns a new ETag on a
+// 200 response the loader updates lastETag and fetches the new repo content.
+func TestUpdate_ETagChange(t *testing.T) {
+	t.Parallel()
+
+	const (
+		etagV1 = `"v1"`
+		etagV2 = `"v2"`
+	)
+	callCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/poll":
+			callCount++
+			switch callCount {
+			case 1:
+				// First call: return ETag v1 + body URL.
+				w.Header().Set("ETag", etagV1)
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("http://" + r.Host + "/repo?v=1"))
+			case 2:
+				// Second call: repo has changed — return 200 with new ETag v2 +
+				// a different body URL to prevent URL-in-body skip.
+				w.Header().Set("ETag", etagV2)
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("http://" + r.Host + "/repo?v=2"))
+			}
+		case "/repo":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"dimension_foo":{"id":"id-root","uri":"/","name":"root","nodes":{},"index":[]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	r := newMinimalRepo(t, srv.URL+"/poll")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go r.UpdateRoutine(ctx)          //nolint:errcheck
+	go r.DimensionUpdateRoutine(ctx) //nolint:errcheck
+
+	// First call — stores v1.
+	_, err := r.update(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, etagV1, r.lastETag)
+
+	// Second call — server returns new ETag v2; loader must update lastETag.
+	_, err = r.update(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, etagV2, r.lastETag, "lastETag must be updated to the new value after 200 response")
+}
+
+// TestUpdate_NoIfNoneMatchOnFirstCall verifies that the very first poll
+// request does not include an If-None-Match header (lastETag is empty at
+// startup).
+func TestUpdate_NoIfNoneMatchOnFirstCall(t *testing.T) {
+	t.Parallel()
+
+	var firstRequestHadIfNoneMatch bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/poll":
+			if r.Header.Get("If-None-Match") != "" {
+				firstRequestHadIfNoneMatch = true
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("http://" + r.Host + "/repo"))
+		case "/repo":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"dimension_foo":{"id":"id-root","uri":"/","name":"root","nodes":{},"index":[]}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	r := newMinimalRepo(t, srv.URL+"/poll")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go r.UpdateRoutine(ctx)          //nolint:errcheck
+	go r.DimensionUpdateRoutine(ctx) //nolint:errcheck
+
+	_, err := r.update(ctx)
+	require.NoError(t, err)
+	assert.False(t, firstRequestHadIfNoneMatch, "first call must NOT include an If-None-Match header")
+}

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -31,6 +31,7 @@ type (
 		poll                       bool
 		pollInterval               time.Duration
 		pollVersion                string
+		lastETag                   string // ETag from the last successful poll response, used for conditional requests
 		onLoaded                   func()
 		loaded                     *atomic.Bool
 		history                    *History

--- a/responses/error.go
+++ b/responses/error.go
@@ -12,7 +12,7 @@ type Error struct {
 }
 
 func (e Error) Error() string {
-	return fmt.Sprintf("status:%q, code: %q, message: %q", e.Status, e.Code, e.Message)
+	return fmt.Sprintf("status:%d, code: %d, message: %q", e.Status, e.Code, e.Message)
 }
 
 // NewError - a brand new error


### PR DESCRIPTION
## Why

Downstream consumers running `--poll=true` against a content-export service want skip-when-unchanged semantics that work with **signed-URL** designs. The current URL-in-body comparison breaks down when the URL contains a signature that changes every request. ETag is the standard HTTP mechanism for exactly this use case and composes cleanly with whatever URL strategy the upstream chooses.

## What changed

- `pkg/repo/repo.go`: new `lastETag` field on `Repo` (zero-value safe).
- `pkg/repo/loader.go`: `update()` now sends `If-None-Match` when a prior ETag exists and short-circuits on `304 Not Modified`. The existing URL-in-body skip is preserved as a fallback.
- `pkg/repo/loader_test.go`: new tests covering backward compatibility, ETag-driven skip, ETag changes, and absent `If-None-Match` on first call.
- `go.mod`: toolchain bumped to Go 1.26.0 (from 1.25.4). Two format-string issues caught by Go 1.26's stricter vet are also fixed.

## Backward compatibility

This change is fully backward-compatible:

- **Server never sends ETag**: `lastETag` stays empty, no `If-None-Match` header is ever sent on the wire, behavior is identical to before this change.
- **First call after process start**: no `If-None-Match` is sent (lastETag is empty); server's response is processed exactly as today, with ETag captured for next time if present.
- **ETag and URL-in-body coexist**: on 200 OK the existing `repoURL == r.pollVersion` skip still runs. ETag short-circuits earlier (avoids body read entirely); URL-in-body remains the fallback for non-ETag-aware servers.

## Test plan

- [x] `go build ./...` passes under Go 1.26.0
- [x] `go test ./... -race` passes (including new tests)
- [x] New tests cover: no-ETag backward compat, ETag → 304 skip, ETag change → fetch new body, no `If-None-Match` on first call.

## Notes

The Go bump is a precondition for downstream services that want to enable Green Tea GC (`GOEXPERIMENT=greentea`, requires Go 1.25+). It also surfaces two latent format-string bugs (`%q` used with `int` arguments in `responses/error.go` and `pkg/repo/loader.go`) that Go 1.26's stricter vet now catches as build errors.