### PR TITLE
feat: go lint modernize

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,6 @@ linters:
     - paralleltest
     - godoclint
     - forbidigo
-    - modernize
     - wsl_v5
     - whitespace
     # Discouraged linters

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -101,11 +101,11 @@ func benchmarkClientAndServerGetContent(tb testing.TB, numGroups, numCalls int, 
 	tb.Helper()
 	var wg sync.WaitGroup
 	wg.Add(numGroups)
-	for group := 0; group < numGroups; group++ {
+	for range numGroups {
 		go func() {
 			defer wg.Done()
 			request := mock.MakeValidContentRequest()
-			for i := 0; i < numCalls; i++ {
+			for range numCalls {
 				response, err := client.GetContent(tb.Context(), request)
 				if err == nil {
 					if request.URI != response.URI {

--- a/client/connectionpool.go
+++ b/client/connectionpool.go
@@ -40,7 +40,7 @@ func (c *connectionPool) run(connectionPoolSize int, waitTimeout time.Duration) 
 		connectionPool = make(map[int]*poolEntry, connectionPoolSize)
 		waitPool       = map[int]*waitPoolEntry{}
 	)
-	for i := 0; i < connectionPoolSize; i++ {
+	for i := range connectionPoolSize {
 		connectionPool[i] = &poolEntry{
 			conn: nil,
 			busy: false,

--- a/client/httptransport.go
+++ b/client/httptransport.go
@@ -67,7 +67,7 @@ func HTTPTransportWithHTTPClient(v *http.Client) HTTPTransportOption {
 // ~ Public methods
 // ------------------------------------------------------------------------------------------------
 
-func (t *HTTPTransport) Call(ctx context.Context, route handler.Route, request interface{}, response interface{}) error {
+func (t *HTTPTransport) Call(ctx context.Context, route handler.Route, request any, response any) error {
 	requestBytes, errMarshal := json.Marshal(request)
 	if errMarshal != nil {
 		return errMarshal

--- a/client/sockettransport.go
+++ b/client/sockettransport.go
@@ -36,7 +36,7 @@ func NewSocketTransport(url string, connectionPoolSize int, waitTimeout time.Dur
 // ~ Public methods
 // ------------------------------------------------------------------------------------------------
 
-func (t *SocketTransport) Call(ctx context.Context, route handler.Route, request interface{}, response interface{}) error {
+func (t *SocketTransport) Call(ctx context.Context, route handler.Route, request any, response any) error {
 	if t.connPool.chanDrainPool == nil {
 		return errors.New("connection pool has been drained, client is dead")
 	}
@@ -57,7 +57,7 @@ func (t *SocketTransport) Call(ctx context.Context, route handler.Route, request
 		}
 	}
 	// write header result will be like handler:2{}
-	jsonBytes = append([]byte(fmt.Sprintf("%s:%d", route, len(jsonBytes))), jsonBytes...)
+	jsonBytes = append(fmt.Appendf(nil, "%s:%d", route, len(jsonBytes)), jsonBytes...)
 
 	// send request
 	var (

--- a/client/transport.go
+++ b/client/transport.go
@@ -7,6 +7,6 @@ import (
 )
 
 type Transport interface {
-	Call(ctx context.Context, route handler.Route, request interface{}, response interface{}) error
+	Call(ctx context.Context, route handler.Route, request any, response any) error
 	Close()
 }

--- a/content/item.go
+++ b/content/item.go
@@ -2,18 +2,18 @@ package content
 
 // Item on a node in a content tree - "payload" of an item
 type Item struct {
-	ID       string                 `json:"id"`
-	Name     string                 `json:"name"`
-	URI      string                 `json:"URI"`
-	MimeType string                 `json:"mimeType"`
-	Hidden   bool                   `json:"hidden,omitempty"`
-	Data     map[string]interface{} `json:"data"`
-	Groups   []string               `json:"groups"`
+	ID       string         `json:"id"`
+	Name     string         `json:"name"`
+	URI      string         `json:"URI"`
+	MimeType string         `json:"mimeType"`
+	Hidden   bool           `json:"hidden,omitempty"`
+	Data     map[string]any `json:"data"`
+	Groups   []string       `json:"groups"`
 }
 
 // NewItem item contructor
 func NewItem() *Item {
 	return &Item{
-		Data: map[string]interface{}{},
+		Data: map[string]any{},
 	}
 }

--- a/content/reponode.go
+++ b/content/reponode.go
@@ -2,23 +2,24 @@ package content
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
 // RepoNode node in a content tree
 type RepoNode struct {
-	ID            string                 `json:"id"`       // unique identifier - it is your responsibility, that they are unique
-	MimeType      string                 `json:"mimeType"` // well a mime type http://www.ietf.org/rfc/rfc2046.txt
-	LinkID        string                 `json:"linkId"`   // (symbolic) link/alias to another node
-	Groups        []string               `json:"groups"`   // which groups have access to the node, if empty everybody has access to it
-	URI           string                 `json:"URI"`
-	Name          string                 `json:"name"`
-	Hidden        bool                   `json:"hidden"`        // hidden in content.nodes, but can still be resolved when being directly addressed
-	DestinationID string                 `json:"destinationId"` // if a node does not have any content like a folder the destinationIds can point to nodes that do aka. the first displayable child node
-	Data          map[string]interface{} `json:"data"`          // what ever you want to stuff into it - the payload you want to attach to a node
-	Nodes         map[string]*RepoNode   `json:"nodes"`         // child nodes
-	Index         []string               `json:"index"`         // defines the order of the child nodes
-	parent        *RepoNode              // parent node - helps to resolve a path / bread crumb
+	ID            string               `json:"id"`       // unique identifier - it is your responsibility, that they are unique
+	MimeType      string               `json:"mimeType"` // well a mime type http://www.ietf.org/rfc/rfc2046.txt
+	LinkID        string               `json:"linkId"`   // (symbolic) link/alias to another node
+	Groups        []string             `json:"groups"`   // which groups have access to the node, if empty everybody has access to it
+	URI           string               `json:"URI"`
+	Name          string               `json:"name"`
+	Hidden        bool                 `json:"hidden"`        // hidden in content.nodes, but can still be resolved when being directly addressed
+	DestinationID string               `json:"destinationId"` // if a node does not have any content like a folder the destinationIds can point to nodes that do aka. the first displayable child node
+	Data          map[string]any       `json:"data"`          // what ever you want to stuff into it - the payload you want to attach to a node
+	Nodes         map[string]*RepoNode `json:"nodes"`         // child nodes
+	Index         []string             `json:"index"`         // defines the order of the child nodes
+	parent        *RepoNode            // parent node - helps to resolve a path / bread crumb
 	// published from - to is going to be an array of fromTos
 }
 
@@ -116,12 +117,7 @@ func (n *RepoNode) IsOneOfTheseMimeTypes(mimeTypes []string) bool {
 	if len(mimeTypes) == 0 {
 		return true
 	}
-	for _, mimeType := range mimeTypes {
-		if mimeType == n.MimeType {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(mimeTypes, n.MimeType)
 }
 
 // CanBeAccessedByGroups can this node be accessed by at least one the given
@@ -133,10 +129,8 @@ func (n *RepoNode) CanBeAccessedByGroups(groups []string) bool {
 	}
 
 	for _, group := range groups {
-		for _, myGroup := range n.Groups {
-			if group == myGroup {
-				return true
-			}
+		if slices.Contains(n.Groups, group) {
+			return true
 		}
 	}
 	return false

--- a/content/sitecontent.go
+++ b/content/sitecontent.go
@@ -7,7 +7,7 @@ type SiteContent struct {
 	Dimension string            `json:"dimension"`
 	MimeType  string            `json:"mimeType"`
 	Item      *Item             `json:"item"`
-	Data      interface{}       `json:"data"`
+	Data      any               `json:"data"`
 	Path      []*Item           `json:"path"`
 	URIs      map[string]string `json:"URIs"`
 	Nodes     map[string]*Node  `json:"nodes"`

--- a/pkg/handler/http.go
+++ b/pkg/handler/http.go
@@ -119,7 +119,7 @@ func (h *HTTP) handleRequest(ctx context.Context, r *repo.Repo, route Route, jso
 
 func (h *HTTP) executeRequest(ctx context.Context, r *repo.Repo, route Route, jsonBytes []byte, source string) (replyBytes []byte, err error) {
 	var (
-		reply             interface{}
+		reply             any
 		apiErr            error
 		jsonErr           error
 		processIfJSONIsOk = func(err error, processingFunc func()) {
@@ -174,8 +174,8 @@ func (h *HTTP) executeRequest(ctx context.Context, r *repo.Repo, route Route, js
 
 // encodeReply takes an interface and encodes it as JSON
 // it returns the resulting JSON and a marshalling error
-func (h *HTTP) encodeReply(reply interface{}) (bytes []byte, err error) {
-	bytes, err = json.Marshal(map[string]interface{}{
+func (h *HTTP) encodeReply(reply any) (bytes []byte, err error) {
+	bytes, err = json.Marshal(map[string]any{
 		"reply": reply,
 	})
 	if err != nil {

--- a/pkg/handler/socket.go
+++ b/pkg/handler/socket.go
@@ -209,7 +209,7 @@ func (h *Socket) handleRequest(r *repo.Repo, route Route, jsonBytes []byte, sour
 
 func (h *Socket) executeRequest(r *repo.Repo, route Route, jsonBytes []byte, source string) (replyBytes []byte, err error) {
 	var (
-		reply             interface{}
+		reply             any
 		apiErr            error
 		jsonErr           error
 		processIfJSONIsOk = func(err error, processingFunc func()) {
@@ -265,8 +265,8 @@ func (h *Socket) executeRequest(r *repo.Repo, route Route, jsonBytes []byte, sou
 
 // encodeReply takes an interface and encodes it as JSON
 // it returns the resulting JSON and a marshalling error
-func (h *Socket) encodeReply(reply interface{}) (replyBytes []byte, err error) {
-	replyBytes, err = json.Marshal(map[string]interface{}{
+func (h *Socket) encodeReply(reply any) (replyBytes []byte, err error) {
+	replyBytes, err = json.Marshal(map[string]any{
 		"reply": reply,
 	})
 	if err != nil {

--- a/pkg/repo/history_test.go
+++ b/pkg/repo/history_test.go
@@ -33,8 +33,8 @@ func TestHistoryCurrent(t *testing.T) {
 func TestHistoryCleanup(t *testing.T) {
 	ctx := context.Background()
 	h := testHistory(t)
-	for i := 0; i < 50; i++ {
-		err := h.Add(ctx, []byte(fmt.Sprint(i)))
+	for i := range 50 {
+		err := h.Add(ctx, fmt.Append(nil, i))
 		require.NoError(t, err)
 		time.Sleep(time.Millisecond * 5)
 	}
@@ -116,9 +116,9 @@ func TestHistoryWithBlobStorage(t *testing.T) {
 	assert.Equal(t, "test-data", buf.String())
 
 	// Test cleanup - add more entries
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		time.Sleep(time.Millisecond * 5) // Ensure unique timestamps
-		err = h.Add(ctx, []byte(fmt.Sprintf("data-%d", i)))
+		err = h.Add(ctx, fmt.Appendf(nil, "data-%d", i))
 		require.NoError(t, err)
 	}
 

--- a/pkg/repo/loader.go
+++ b/pkg/repo/loader.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -409,12 +410,7 @@ func (r *Repo) loadNodes(newNodes map[string]*content.RepoNode) error {
 		return errors.Wrap(err, "failed to update dimension")
 	}
 	dimensionIsValid := func(dimension string) bool {
-		for _, newDimension := range newDimensions {
-			if dimension == newDimension {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(newDimensions, dimension)
 	}
 	// we need to throw away orphaned dimensions
 	directory := map[string]*Dimension{}

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -268,7 +268,7 @@ func TestWriteRepoBytesRace(t *testing.T) {
 	defer cancel()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()

--- a/pkg/repo/storage_blob_test.go
+++ b/pkg/repo/storage_blob_test.go
@@ -175,7 +175,7 @@ func TestBlobStorage_ConcurrentOperations(t *testing.T) {
 	storage := newTestBlobStorage(t, "")
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/pkg/repo/storage_fs_test.go
+++ b/pkg/repo/storage_fs_test.go
@@ -127,7 +127,7 @@ func TestFilesystemStorage_ConcurrentOperations(t *testing.T) {
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()


### PR DESCRIPTION
### Description

Enable the golangci-lint `modernize` linter and apply its suggested fixes across the codebase.

### Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [x] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [x] 🔧 Build/CI

### Changes

- Enable the `modernize` linter in `.golangci.yaml` (removed from the disabled list)
- Replace `interface{}` with `any` throughout (`content`, `client`, `pkg/handler`)
- Convert C-style counter loops to `for range n` / `for i := range n`
- Replace manual membership loops with `slices.Contains` (`content/reponode.go`, `pkg/repo/loader.go`)
- Use `fmt.Appendf`/`fmt.Append` instead of `[]byte(fmt.Sprintf(...))`

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.

#### Notes

All changes are mechanical, produced by `golangci-lint` autofixes; no behavioral changes intended.
