### PR TITLE
Preserve Error Chains for Invalid Requests and Deserialize Failures

### DIFF
--- a/pkg/repo/loader.go
+++ b/pkg/repo/loader.go
@@ -223,7 +223,7 @@ func (r *Repo) loadNodesFromJSON() (nodes map[string]*content.RepoNode, err erro
 
 	err = json.Unmarshal(r.JSONBufferBytes(), &nodes)
 	if err != nil {
-		return nil, errors.New("failed to deserialize nodes")
+		return nil, errors.Wrap(err, "failed to deserialize nodes")
 	}
 
 	return nodes, nil

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -55,6 +55,10 @@ type (
 
 type invalidRequestError struct{ error }
 
+func (e invalidRequestError) Unwrap() error {
+	return e.error
+}
+
 func IsInvalidRequest(err error) bool {
 	var target invalidRequestError
 	return errors.As(err, &target)


### PR DESCRIPTION
Follow-up to #92.

- `invalidRequestError` now implements `Unwrap`, so `errors.Unwrap`, `errors.Is` and `pkg/errors.Cause` reach the underlying validation error and zap keeps the stack field.
- `loadNodesFromJSON` wraps the JSON parser error instead of replacing it, so the "update failed" log and the update response carry the actual parse failure.

No flag, wire or metric changes.
