### PR TITLE
Apply Repository Timeout To Response Header Wait

### DIFF
--- a/cmd/http.go
+++ b/cmd/http.go
@@ -10,7 +10,6 @@ import (
 	"github.com/foomo/contentserver/pkg/repo"
 	"github.com/foomo/keel"
 	"github.com/foomo/keel/healthz"
-	keelhttp "github.com/foomo/keel/net/http"
 	"github.com/foomo/keel/net/http/middleware"
 	"github.com/foomo/keel/service"
 	"github.com/spf13/cobra"
@@ -77,12 +76,7 @@ func NewHTTPCommand() *cobra.Command {
 			r := repo.New(l.Named("inst.repo"),
 				args[0],
 				history,
-				repo.WithHTTPClient(
-					keelhttp.NewInternalHTTPClient(
-						keelhttp.HTTPClientWithTimeout(repositoryTimeoutFlag(v)),
-						keelhttp.HTTPClientWithTelemetry(),
-					),
-				),
+				repo.WithHTTPClient(newRepositoryHTTPClient(true, repositoryTimeoutFlag(v))),
 				repo.WithPollInterval(pollIntevalFlag(v)),
 				repo.WithPoll(pollFlag(v)),
 				repo.WithLogLevelMissingNode(logLevelMissingNode),

--- a/cmd/httpclient.go
+++ b/cmd/httpclient.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"net/http"
+	"time"
+
+	keelhttp "github.com/foomo/keel/net/http"
+)
+
+// newRepositoryHTTPClient builds the client used to fetch and poll the
+// repository. keel's transports give up on response headers after a few
+// seconds, which is shorter than a cold repository export takes to build, so
+// the repository timeout has to bound the header wait as well as the request.
+func newRepositoryHTTPClient(internal bool, timeout time.Duration) *http.Client {
+	newClient := keelhttp.NewExternalHTTPClient
+	if internal {
+		newClient = keelhttp.NewInternalHTTPClient
+	}
+
+	return newClient(
+		keelhttp.HTTPClientWithTimeout(timeout),
+		keelhttp.HTTPClientWithResponseHeaderTimeout(timeout),
+		keelhttp.HTTPClientWithTelemetry(),
+	)
+}

--- a/cmd/httpclient_test.go
+++ b/cmd/httpclient_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// keel's transports stop waiting for response headers after 5s (internal) or
+// 10s (external). A cold contentserverexport poll takes longer than that, so
+// the repository timeout has to govern the header wait as well.
+func TestNewRepositoryHTTPClientWaitsForSlowHeaders(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		internal    bool
+		headerDelay time.Duration
+	}{
+		"internal": {internal: true, headerDelay: 6 * time.Second},
+		"external": {internal: false, headerDelay: 11 * time.Second},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				select {
+				case <-time.After(tc.headerDelay):
+					w.WriteHeader(http.StatusOK)
+				case <-r.Context().Done():
+				}
+			}))
+			t.Cleanup(srv.Close)
+
+			client := newRepositoryHTTPClient(tc.internal, 30*time.Second)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			require.NoError(t, err)
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+
+			t.Cleanup(func() { _ = resp.Body.Close() })
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		})
+	}
+}

--- a/cmd/socket.go
+++ b/cmd/socket.go
@@ -8,7 +8,6 @@ import (
 	"github.com/foomo/contentserver/pkg/handler"
 	"github.com/foomo/contentserver/pkg/repo"
 	"github.com/foomo/keel/log"
-	keelhttp "github.com/foomo/keel/net/http"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -66,12 +65,7 @@ func NewSocketCommand() *cobra.Command {
 			r := repo.New(l,
 				args[0],
 				history,
-				repo.WithHTTPClient(
-					keelhttp.NewExternalHTTPClient(
-						keelhttp.HTTPClientWithTimeout(repositoryTimeoutFlag(v)),
-						keelhttp.HTTPClientWithTelemetry(),
-					),
-				),
+				repo.WithHTTPClient(newRepositoryHTTPClient(false, repositoryTimeoutFlag(v))),
 				repo.WithPoll(pollFlag(v)),
 				repo.WithPollInterval(pollIntevalFlag(v)),
 				repo.WithLogLevelMissingNode(logLevelMissingNode),


### PR DESCRIPTION
## Problem

Since 1.21.0 the repository client is built with keel's `NewInternalHTTPClient` (http command) and `NewExternalHTTPClient` (socket command). keel 0.29 hardcodes `ResponseHeaderTimeout` on those transports: 5s internal, 10s external. `--repository-timeout` only sets `http.Client.Timeout`, so the header timeout fires first.

A cold `contentserverexport` poll builds the export synchronously and takes longer than 5s. Every poll is cancelled with `net/http: timeout awaiting response headers`, the export keeps working on already-cancelled requests, and each poller adds another request every poll interval. The new pod never loads a repository, its startup probe stays 503, and it restarts until the export happens to finish for a still-connected client. This aborted two production rollouts on 2026-09-10.

## Fix

`newRepositoryHTTPClient` builds the client for both commands and passes the repository timeout to `HTTPClientWithResponseHeaderTimeout` as well, before telemetry wraps the transport (keel panics otherwise).

## Verification

`TestNewRepositoryHTTPClientWaitsForSlowHeaders` serves headers after 6s (internal) and 11s (external) with a 30s repository timeout. Against the previous construction it fails with the production error on both paths; with this change it passes. `make tidy`, `make lint`, `make test` clean locally.
